### PR TITLE
v 0.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(vector_slicer VERSION 0.8.0)
+project(vector_slicer VERSION 0.8.1)
 
 set(Boost_NO_WARN_NEW_VERSIONS 1)
 find_package(Boost COMPONENTS system filesystem REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,8 @@ set(SOURCES
         source/pattern/path_sorting/nearest_neighbour.h
         source/pattern/coord.h
         source/pattern/position.h
-        source/pattern/coord.cpp)
+        source/pattern/coord.cpp
+)
 
 add_executable(Vector_Slicer main.cpp
         ${SOURCES})

--- a/bayesopt/CMakeLists.txt
+++ b/bayesopt/CMakeLists.txt
@@ -19,7 +19,7 @@
 # ------------------------------------------------------------------------
 
 PROJECT(BayesOpt CXX)
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 11)

--- a/bayesopt/nlopt2/CMakeLists.txt
+++ b/bayesopt/nlopt2/CMakeLists.txt
@@ -17,7 +17,7 @@
 #==============================================================================
 
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 enable_language(C)
 INCLUDE(CheckIncludeFiles)
 INCLUDE(CheckFunctionExists)

--- a/install_win.bat
+++ b/install_win.bat
@@ -6,23 +6,29 @@ set pwd=%mypath:~0,-1%
 IF EXIST "C:\src\vcpkg\" (
     cd C:\src\vcpkg\
     git pull
-    vcpkg install boost:x64-windows
-    vcpkg integrate install
 ) else (
      mkdir C:\src
      cd C:\src
      git clone https://github.com/Microsoft/vcpkg.git
      cd vcpkg && bootstrap-vcpkg.bat
-     vcpkg install boost:x64-windows
-     vcpkg integrate install
 )
+
+vcpkg install boost:x64-windows
+vcpkg integrate install
 
 set cmake_path="C:/src/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 echo Installing Vector Slicer
 cd %pwd%
 
-git pull
+IF EXIST ".git" (
+    git pull
+) else (
+    echo Warning: Git directory does not exist, which will prevent you from easily updating the project in the future.
+    echo Please consider cloning the GitHub repository, by going into the desired parent directory and running:
+    echo git clone https://github.com/Zmmyslony/vector_slicer.git
+)
+
 cmake -S ./ -B ./build -DCMAKE_TOOLCHAIN_FILE=%cmake_path%
 cmake --build ./build --config Release -j4
 

--- a/python/lib/output_reading.py
+++ b/python/lib/output_reading.py
@@ -34,30 +34,18 @@ Reading and plotting the slicer output.
 #  You should have received a copy of the GNU General Public License along with Vector Slicer.
 #  If not, see <https://www.gnu.org/licenses/>.
 
-from . import slicer_setup as slicer
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import numpy as np
-import os.path
+from lib import project_paths
 import math
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-
-def get_slicer_output_directory():
-    slicer_directory = slicer.get_project_directory()
-    output_directory = slicer_directory / "output"
-    return output_directory
-
-
-def get_plot_output_directory():
-    plot_output_directory = slicer.get_project_directory() / "python" / "output"
-    if not os.path.exists(plot_output_directory):
-        os.mkdir(plot_output_directory)
-    return plot_output_directory
+from lib.pattern.pattern import Pattern
 
 
 def read_fill_matrix(pattern_name):
-    input_path = get_slicer_output_directory() / "filled_matrices" / (pattern_name + ".csv")
+    input_path = project_paths.get_slicer_output_directory() / "filled_matrices" / (pattern_name + ".csv")
     data = np.genfromtxt(input_path, dtype=int, delimiter=",").transpose()
     return data
 
@@ -96,7 +84,7 @@ def read_optimisation_sequence(pattern_name) -> list:
     :param pattern_name:
     :return: List of disagreements in each optimisation iteration.
     """
-    input_path = get_slicer_output_directory() / "optimisation_save" / (pattern_name + ".txt")
+    input_path = project_paths.get_slicer_output_directory() / "optimisation_save" / (pattern_name + ".txt")
 
     file = open(input_path, "r")
     optimisation_sequence = []
@@ -135,7 +123,7 @@ def read_paths(pattern_name):
     :param pattern_name:
     :return:
     """
-    input_path = get_slicer_output_directory() / "paths" / (pattern_name + ".csv")
+    input_path = project_paths.get_slicer_output_directory() / "paths" / (pattern_name + ".csv")
 
     file = open(input_path, "r")
     list_of_lines = []
@@ -151,7 +139,7 @@ def read_paths(pattern_name):
 
 
 def read_seeds(pattern_name):
-    input_path = get_slicer_output_directory() / "used_seeds" / (pattern_name + ".csv")
+    input_path = project_paths.get_slicer_output_directory() / "used_seeds" / (pattern_name + ".csv")
     seeds = np.genfromtxt(input_path, delimiter=",")
     return seeds
 
@@ -173,11 +161,11 @@ def plot_paths(axis: plt.axis, list_of_lines, is_non_printing_moves_shown=True):
     return axis
 
 
-def plot_pattern(pattern_name, axis: plt.axis = None, is_fill_density_shown=True, is_paths_shown=True,
+def plot_pattern(pattern: str or Pattern, axis: plt.axis = None, is_fill_density_shown=True, is_paths_shown=True,
                  is_axes_shown=True, max_fill_value=None, is_non_printing_moves_shown=True, is_seeds_shown=False):
     """
     Plots the sliced pattern with fill density (gray), printing moves (blue) and non-printing moves (orange).
-    :param pattern_name:
+    :param pattern:
     :param axis: If specified the plots will not be immediately shown but returned for further manipulation.
     :param is_fill_density_shown: allows to choose whether gray background showing the fill density is shown.
     :param is_paths_shown: allows to choose printer movements are shown.
@@ -186,6 +174,10 @@ def plot_pattern(pattern_name, axis: plt.axis = None, is_fill_density_shown=True
     :param max_fill_value: maximum value of the fill matrix.
     :return:
     """
+    if isinstance(pattern, Pattern):
+        pattern_name = pattern.name
+    else:
+        pattern_name = pattern
 
     if axis is None:
         fig = plt.figure(figsize=[6, 4], dpi=300)
@@ -216,17 +208,17 @@ def plot_pattern(pattern_name, axis: plt.axis = None, is_fill_density_shown=True
         plt.tight_layout()
 
     if axis is None:
-        save_name = get_plot_output_directory() / f"{pattern_name}_pattern.svg"
+        save_name = project_paths.get_plot_output_directory() / f"{pattern_name}_pattern.svg"
         plt.savefig(save_name, transparent=True)
         plt.show()
     return axis
 
 
 def plot_director_distribution_disagreement(pattern_name, bucket_count=None):
-    input_path = get_slicer_output_directory() / "bucketed_disagreement" / (pattern_name + ".csv")
+    input_path = project_paths.get_slicer_output_directory() / "bucketed_disagreement" / (pattern_name + ".csv")
     original_data = np.genfromtxt(input_path, delimiter=",")
-    original_data /= np.sum(original_data) # Normalize
-    original_data *= 100 # Percentages
+    original_data /= np.sum(original_data)  # Normalize
+    original_data *= 100  # Percentages
     original_angle_separators = np.linspace(0, 90, original_data.shape[0], endpoint=True)
     if bucket_count is not None:
         interval = math.ceil(original_data.shape[0] / bucket_count)
@@ -260,7 +252,7 @@ def plot_disagreement_progress(pattern_name):
     ax.set_xlabel("iteration")
     ax.set_ylabel("disagreement")
     ax.legend()
-    save_name = get_plot_output_directory() / f"{pattern_name}_disagreement_progress.svg"
+    save_name = project_paths.get_plot_output_directory() / f"{pattern_name}_disagreement_progress.svg"
     plt.savefig(save_name)
 
     plt.show()

--- a/python/lib/pattern/pattern.py
+++ b/python/lib/pattern/pattern.py
@@ -44,11 +44,10 @@ import matplotlib as mpl
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from lib.director.director import Director
-from lib.output_reading import get_plot_output_directory
+from lib.project_paths import get_plot_output_directory
 from lib.shape.shape import Shape
 from lib.shape.basic import regular_hexagon, square, regular_triangle
-from lib import slicer_setup as slicer
-
+from lib import project_paths
 
 def refine_low_magnitude_splay(shape_grid, theta_grid, splay):
     splay_magnitude = np.linalg.norm(splay, axis=2)
@@ -372,10 +371,10 @@ class Pattern:
 
         current_stage = 3
         if pattern_name is not None:
-            pattern_directory = slicer.get_patterns_directory() / pattern_name
+            pattern_directory = project_paths.get_patterns_directory() / pattern_name
             if not pattern_directory.exists():
-                if not slicer.get_patterns_directory().exists():
-                    os.mkdir(slicer.get_patterns_directory())
+                if not project_paths.get_patterns_directory().exists():
+                    os.mkdir(project_paths.get_patterns_directory())
                 os.mkdir(pattern_directory)
 
             np.savetxt(pattern_directory / "shape.csv", shape_grid, delimiter=',', fmt="%d")

--- a/python/lib/project_paths.py
+++ b/python/lib/project_paths.py
@@ -1,0 +1,27 @@
+import os
+import pathlib
+
+def get_project_directory():
+    """
+    :return: Vector Slicer directory
+    """
+    return pathlib.Path().absolute().parent
+
+
+def get_patterns_directory():
+    """
+    :return: Patterns (input) directory.
+    """
+    return get_project_directory() / "patterns"
+
+def get_slicer_output_directory():
+    slicer_directory = get_project_directory()
+    output_directory = slicer_directory / "output"
+    return output_directory
+
+
+def get_plot_output_directory():
+    plot_output_directory = get_project_directory() / "python" / "output"
+    if not os.path.exists(plot_output_directory):
+        os.mkdir(plot_output_directory)
+    return plot_output_directory

--- a/python/lib/slicer.py
+++ b/python/lib/slicer.py
@@ -34,12 +34,8 @@ Slicer object used for slicing the director patterns.
 #  You should have received a copy of the GNU General Public License along with Vector Slicer.
 #  If not, see <https://www.gnu.org/licenses/>.
 
-import ctypes
-import pathlib
-import sys
-import os
-
 from lib import slicer_setup
+from lib.pattern.pattern import Pattern
 
 
 class Slicer:
@@ -47,41 +43,41 @@ class Slicer:
         self.slicer = slicer_setup.import_slicer(build_directory)
         slicer_setup.configure_slicer(self.slicer)
 
-    def slice(self, pattern_file_name: str, use_default=True):
+    def slice(self, pattern: str or Pattern, use_default=True):
         """
         Slices the pattern name using either default configuration or opening a prompt asking for modifications.
-        :param pattern_file_name:
+        :param pattern:
         :param use_default:
         :return:
         """
-        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern_file_name)
+        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern)
         self.slicer.slice_pattern(input_name, use_default)
 
-    def re_slice(self, pattern_file_name: str):
+    def re_slice(self, pattern: str or Pattern):
         """
         Re-slices the pattern using the best config exported during prior optimisation.
-        :param pattern_file_name:
+        :param pattern:
         :return:
         """
-        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern_file_name)
+        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern)
         self.slicer.re_slice_pattern(input_name)
 
-    def slice_seeds_only(self, pattern_file_name: str, seeds: int):
+    def slice_seeds_only(self, pattern: str or Pattern, seeds: int):
         """
         Slices the pattern using the config in the input directory for a given number of seeds.
-        :param pattern_file_name:
+        :param pattern:
         :param seeds:
         :return:
         """
-        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern_file_name)
+        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern)
         self.slicer.slice_pattern_seeds_only(input_name, seeds)
 
-    def slice_variable_width(self, pattern_file_name: str, seeds: int):
+    def slice_variable_width(self, pattern: str or Pattern, seeds: int):
         """
                 Slices the pattern using the config in the input with a variable width preset for a given number of seeds.
-                :param pattern_file_name:
+                :param pattern:
                 :param seeds:
                 :return:
                 """
-        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern_file_name)
+        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern)
         self.slicer.slice_pattern_variable_width(input_name, seeds)

--- a/python/lib/slicer.py
+++ b/python/lib/slicer.py
@@ -75,3 +75,13 @@ class Slicer:
         """
         input_name = slicer_setup.convert_pattern_name_into_input_name(pattern_file_name)
         self.slicer.slice_pattern_seeds_only(input_name, seeds)
+
+    def slice_variable_width(self, pattern_file_name: str, seeds: int):
+        """
+                Slices the pattern using the config in the input with a variable width preset for a given number of seeds.
+                :param pattern_file_name:
+                :param seeds:
+                :return:
+                """
+        input_name = slicer_setup.convert_pattern_name_into_input_name(pattern_file_name)
+        self.slicer.slice_pattern_variable_width(input_name, seeds)

--- a/python/lib/slicer_setup.py
+++ b/python/lib/slicer_setup.py
@@ -64,6 +64,7 @@ def configure_slicer(slicer):
     slicer.slice_pattern_with_config.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     slicer.re_slice_pattern.argtypes = [ctypes.c_char_p]
     slicer.slice_pattern_seeds_only.argtypes = [ctypes.c_char_p, ctypes.c_int]
+    slicer.slice_pattern_variable_width.argtypes = [ctypes.c_char_p, ctypes.c_int]
 
 
 def import_slicer(build_directory=None):

--- a/python/lib/slicer_setup.py
+++ b/python/lib/slicer_setup.py
@@ -35,23 +35,10 @@ Configuration of the slicer library.
 #  If not, see <https://www.gnu.org/licenses/>.
 
 import ctypes
-import pathlib
 import sys
 import os
-
-
-def get_project_directory():
-    """
-    :return: Vector Slicer directory
-    """
-    return pathlib.Path().absolute().parent
-
-
-def get_patterns_directory():
-    """
-    :return: Patterns (input) directory.
-    """
-    return get_project_directory() / "patterns"
+from lib import project_paths
+from lib.pattern.pattern import Pattern
 
 
 def configure_slicer(slicer):
@@ -79,7 +66,7 @@ def import_slicer(build_directory=None):
             raise Exception("VECTOR_SLICER_API environment variable is not set to point to the built library.")
 
     else:
-        project_directory = get_project_directory()
+        project_directory = project_paths.get_project_directory()
         if sys.platform == "win32":
             library_name = "vector_slicer_api.dll"
         elif sys.platform == "linux":
@@ -93,21 +80,27 @@ def import_slicer(build_directory=None):
 
 
     if not os.path.exists(vector_slicer_lib_path):
-        print(f"Vector Slicer Api does not exist in \"{vector_slicer_lib_path}\". Remember to build it and choose the "
+        print(f"Vector Slicer api does not exist in \"{vector_slicer_lib_path}\". Remember to build it and choose the "
               f"correct build directory.")
         raise Exception('api_not_found')
+    else:
+        print(f"Vector Slicer api found in \"{vector_slicer_lib_path}\".")
 
     slicer = ctypes.CDLL(str(vector_slicer_lib_path))
     return slicer
 
 
-def convert_pattern_name_into_input_name(pattern_name: str):
+def convert_pattern_name_into_input_name(pattern: str or Pattern):
     """
     Converts string filename to binary format used by the library.
-    :param pattern_name:
+    :param pattern:
     :return: UTF-8 encoded path.
     """
-    patterns_directory = get_patterns_directory()
+    if isinstance(pattern, Pattern):
+        pattern_name = pattern.name
+    else :
+        pattern_name = pattern
+    patterns_directory = project_paths.get_patterns_directory()
     pattern_name = patterns_directory / pattern_name
     pattern_name_b = str(pattern_name).encode('utf-8')
     return pattern_name_b

--- a/source/bayesian_optimisation.cpp
+++ b/source/bayesian_optimisation.cpp
@@ -532,7 +532,7 @@ void variableWidthOptimisation(const fs::path &pattern_path, int seeds) {
     std::cout << "\n\nCurrent directory: " << pattern_path << std::endl;
 
     Simulation simulation(pattern_path, true);
-    simulation.setOverlapWeight(simulation.getOverlapWeight() / 100);
+    simulation.setOverlapWeight(simulation.getEmptySpotWeight() / 1000);
     fs::path config_path = pattern_path / "config.txt";
     FillingConfig optimised_config(config_path);
     optimised_config.convertToVariableWidth();

--- a/source/bayesian_optimisation.h
+++ b/source/bayesian_optimisation.h
@@ -82,4 +82,7 @@ void recalculateBestConfig(const fs::path &pattern_path);
 
 /// Scans a certain number of seeds and finds the best one.
 void optimisePatternSeeds(const fs::path &pattern_path, const fs::path &config_path, int seeds);
+
+/// Same as optimise PatternSeeds, but uses the config from the pattern path.
+void variableWidthOptimisation(const fs::path &pattern_path, int seeds);
 #endif //VECTOR_SLICER_BAYESIAN_OPTIMISATION_H

--- a/source/pattern/auxiliary/geometry.cpp
+++ b/source/pattern/auxiliary/geometry.cpp
@@ -40,7 +40,7 @@ isLeftOfEdge(const coord &point, const coord_d &edge_point_first, const coord_d 
     if (is_exclusive) {
         return cross_product > 0;
     } else {
-        return cross_product >= 0;
+        return cross_product > -1e-6;
     }
 }
 

--- a/source/pattern/auxiliary/geometry.cpp
+++ b/source/pattern/auxiliary/geometry.cpp
@@ -36,12 +36,7 @@ isLeftOfEdge(const coord &point, const coord_d &edge_point_first, const coord_d 
     double cross_product =
             (edge_point_second.x - edge_point_first.x) * (point.y - edge_point_first.y) -
             (edge_point_second.y - edge_point_first.y) * (point.x - edge_point_first.x);
-
-    if (is_exclusive) {
-        return cross_product > 0;
-    } else {
-        return cross_product > -1e-6;
-    }
+    return cross_product > (is_exclusive ? 0 : -1e-6);
 }
 
 bool isLeftOfEdge(const coord_d &point, const coord_d &edge_point_first, const coord_d &edge_point_second,
@@ -50,11 +45,7 @@ bool isLeftOfEdge(const coord_d &point, const coord_d &edge_point_first, const c
             (edge_point_second.x - edge_point_first.x) * (point.y - edge_point_first.y) -
             (edge_point_second.y - edge_point_first.y) * (point.x - edge_point_first.x);
 
-    if (is_exclusive) {
-        return cross_product > 0;
-    } else {
-        return cross_product >= 0;
-    }
+    return cross_product > (is_exclusive ? 0 : -1e-6);
 }
 
 bool isInRectangle(const coord_d &point, const coord_d &corner_first, const coord_d &corner_second,

--- a/source/pattern/auxiliary/geometry.cpp
+++ b/source/pattern/auxiliary/geometry.cpp
@@ -121,6 +121,10 @@ std::vector<coord> findPointsToFill(coord_d corner_first, coord_d corner_second,
     }
 
     std::vector<coord> coords_to_fill;
+    if ((x_max  + 1 - x_min) * (y_max + 1 - y_min) > 1e6) {
+        std::cout << x_min << " " << x_max << " " << y_min << " " << y_max << std::endl;
+        throw std::runtime_error("More than 1e6 points are scanned when looking for points to fill.");
+    }
     for (int x_curr = x_min; x_curr <= x_max; x_curr++) {
         for (int y_curr = y_min; y_curr <= y_max; y_curr++) {
             coord pos ={x_curr, y_curr};

--- a/source/pattern/auxiliary/line_operations.cpp
+++ b/source/pattern/auxiliary/line_operations.cpp
@@ -28,27 +28,27 @@
 #include <cmath>
 
 #include "valarray_operations.h"
-#include "simple_math_operations.h"
 
 
-void removeElement(std::vector<coord> &array, int index) {
-    array.erase(array.begin() + index);
-}
+coord findClosestNeighbour(coord_set &array, coord &element) {
+    coord closest_element = *array.begin();
 
-coord findClosestNeighbour(std::vector<coord> &array, coord &element) {
-    coord closest_element;
-    auto closest_distance = DBL_MAX;
+    std::vector<coord> displacements = {{1,  0},
+                                        {0,  1},
+                                        {-1, 0},
+                                        {0,  -1},
+                                        {1,  1},
+                                        {-1, 1},
+                                        {-1, -1},
+                                        {1,  -1}};
 
-    int i_min = 0;
-    for (int i = 0; i < array.size(); i++) {
-        double distance = norm(array[i] - element);
-        if (distance < closest_distance) {
-            closest_element = array[i];
-            i_min = i;
-            closest_distance = distance;
+    for (const coord &displacement: displacements) {
+        if (array.find(element + displacement) != array.end()) {
+            closest_element = element + displacement;
+            break;
         }
     }
-    removeElement(array, i_min);
+    array.erase(element);
     return closest_element;
 }
 
@@ -60,7 +60,7 @@ bool isLooped(const std::vector<coord> &line) {
 }
 
 std::vector<std::vector<coord>>
-separateIntoLines(std::vector<coord> &unsorted_perimeters, coord starting_coordinates, double separation_distance) {
+separateIntoLines(coord_set &unsorted_perimeters, coord starting_coordinates, double separation_distance) {
     coord current_element = findClosestNeighbour(unsorted_perimeters, starting_coordinates);
     std::vector<std::vector<coord>> forwards_paths;
     std::vector<std::vector<coord>> backwards_paths;

--- a/source/pattern/auxiliary/line_operations.h
+++ b/source/pattern/auxiliary/line_operations.h
@@ -35,7 +35,7 @@ using veci = std::vector<int>;
 std::vector<std::vector<veci>> separateLines(std::vector<veci> &sorted_perimeters, double separation_distance);
 
 std::vector<std::vector<coord>>
-separateIntoLines(std::vector<coord> &unsorted_perimeters, coord starting_coordinates, double separation_distance);
+separateIntoLines(coord_set &unsorted_perimeters, coord starting_coordinates, double separation_distance);
 
 bool isLooped(const std::vector<coord> &line);
 

--- a/source/pattern/auxiliary/line_thinning.cpp
+++ b/source/pattern/auxiliary/line_thinning.cpp
@@ -131,19 +131,19 @@ coord_set skeletonize(coord_set shape, int grow_size, const std::vector<std::vec
     shape = grow_pattern(shape, grow_size, shape_matrix);
     /// Instead of doing the skeletonisation until convergence, we only aim to reduce what was added by the growth.
     for (int i = 0; i <= grow_size * 2; i++) {
-        coord_vector coordinates_to_remove_stage_one;
+        coord_set coordinates_to_remove_stage_one;
         for (auto &coordinate: shape) {
             if (isRemovedEastSouth(shape, coordinate)) {
-                coordinates_to_remove_stage_one.emplace_back(coordinate);
+                coordinates_to_remove_stage_one.insert(coordinate);
             }
         }
 
         for (auto &coordinate: coordinates_to_remove_stage_one) { shape.erase(coordinate); }
 
-        coord_vector coordinates_to_remove_stage_two;
+        coord_set coordinates_to_remove_stage_two;
         for (auto &coordinate: shape) {
             if (isRemovedNorthWest(shape, coordinate)) {
-                coordinates_to_remove_stage_two.emplace_back(coordinate);
+                coordinates_to_remove_stage_two.insert(coordinate);
             }
         }
 

--- a/source/pattern/auxiliary/perimeter.cpp
+++ b/source/pattern/auxiliary/perimeter.cpp
@@ -138,30 +138,30 @@ bool isValidPerimeterPoint(const coord &positions, const std::vector<std::vector
     return dot(outward_pointing_vector, current_splay) > zero_splay_threshold;
 }
 
-std::vector<coord> findValidPerimeterPoints(const std::vector<std::vector<uint8_t>> &shape_matrix, const veci &sizes,
-                                            const std::vector<std::vector<coord_d>> &splay_array) {
-    std::vector<coord> unsorted_perimeters;
+coord_set findValidPerimeterPoints(const std::vector<std::vector<uint8_t>> &shape_matrix, const veci &sizes,
+                                   const std::vector<std::vector<coord_d>> &splay_array) {
+    coord_set unsorted_perimeters;
     std::vector<coord> tested_circle = circleDisplacements(4);
     for (int i = 0; i < sizes[0]; i++) {
         for (int j = 0; j < sizes[1]; j++) {
             coord current_position = {i, j};
             if (isValidPerimeterPoint({i, j}, shape_matrix, sizes, tested_circle, splay_array)) {
-                unsorted_perimeters.push_back(current_position);
+                unsorted_perimeters.insert(current_position);
             }
         }
     }
     return unsorted_perimeters;
 }
 
-std::vector<coord> findGeometricalPerimeter(const std::vector<std::vector<uint8_t>> &shape_matrix, const veci &sizes) {
-    std::vector<coord> unsorted_perimeters;
+coord_set findGeometricalPerimeter(const std::vector<std::vector<uint8_t>> &shape_matrix, const veci &sizes) {
+    coord_set unsorted_perimeters;
     // It is set to constant radius, maybe add a control over it?
     std::vector<coord> tested_circle = circleDisplacements(4);
     for (int i = 0; i < sizes[0]; i++) {
         for (int j = 0; j < sizes[1]; j++) {
             coord current_position = {i, j};
             if (isOnEdge(shape_matrix, {i, j}, sizes)) {
-                unsorted_perimeters.push_back(current_position);
+                unsorted_perimeters.insert(current_position);
             }
         }
     }
@@ -172,7 +172,7 @@ std::vector<coord> findGeometricalPerimeter(const std::vector<std::vector<uint8_
 std::vector<std::vector<coord>>
 findSeparatedPerimeters(const std::vector<std::vector<uint8_t>> &shape_matrix, const veci &sizes,
                         const std::vector<std::vector<coord_d>> &splay_array) {
-    std::vector<coord> unsorted_perimeters = findValidPerimeterPoints(shape_matrix, sizes, splay_array);
+    coord_set unsorted_perimeters = findValidPerimeterPoints(shape_matrix, sizes, splay_array);
     std::vector<std::vector<coord>> separated_perimeters = separateIntoLines(unsorted_perimeters, {0, 0}, 2);
     // If using the splay approach for selecting splay-valid perimeter points yields single points that are unconnected
     // then separation into perimeters will not detect any lines. Therefore, we revert to the simple geometrical

--- a/source/pattern/auxiliary/repulsion.cpp
+++ b/source/pattern/auxiliary/repulsion.cpp
@@ -33,13 +33,13 @@
 
 
 std::vector<coord> generateLineDisplacements(const coord_d &tangent, double radius) {
-    coord_d normal = normalized(perpendicular(tangent)) * radius;
+    coord_d normal = perpendicular(tangent) * (radius / norm(tangent));
 
     int distance_i = (int) std::max(fabs(normal.x), fabs(normal.y));
     std::vector<coord> displacement_list;
+    displacement_list.reserve(2 * distance_i + 1);
     for (int i = -distance_i; i <= distance_i; i++) {
-        coord_d displacement_d = normal * (double) i / (double) distance_i;
-        displacement_list.emplace_back(displacement_d);
+        displacement_list.emplace_back(normal * ((double) i / (double) distance_i));
     }
     return displacement_list;
 }

--- a/source/pattern/coord.cpp
+++ b/source/pattern/coord.cpp
@@ -69,7 +69,8 @@ bool coord_d::operator==(const coord_d &other) const {
 }
 
 double coord_d::norm() const {
-    return sqrt(x * x + y * y);
+    double norm = sqrt(x * x + y * y);
+    return norm != 0 ? norm : 1e-6;
 }
 
 coord_d coord_d::normalized() const {
@@ -109,7 +110,8 @@ void coord::operator*=(int multiplier) {
 }
 
 double coord::norm() const {
-    return sqrt(x * x + y * y);
+    double norm = sqrt(x * x + y * y);
+    return norm != 0 ? norm : 1e-6;
 }
 
 coord_d coord::normalized() const {

--- a/source/pattern/coord.h
+++ b/source/pattern/coord.h
@@ -128,7 +128,7 @@ inline coord_d normalized(const coord_d &pt) { return pt.normalized(); }
 struct coord_hash {
 public:
     unsigned int operator()(const coord &x) const {
-        return ((int) x.x + 32768) * 65536 + ((int)x.y + 32768);
+        return (int) x.x * (int) x.x - (int) x.y ;
     }
 };
 

--- a/source/pattern/desired_pattern.cpp
+++ b/source/pattern/desired_pattern.cpp
@@ -586,17 +586,13 @@ void DesiredPattern::findLineDensityMinima() {
     std::cout << "\rSearch for seeding lines complete." << std::endl;
     solution_set = skeletonize(solution_set, 10, shape_matrix);
 //    exportCoord(solution_set, "/home/mlz22/OneDrive/tmp/splay_lines.csv");
-    std::vector<coord> line_density_minima_local;
-    for (auto &vector: solution_set) {
-        line_density_minima_local.emplace_back(coord{vector.x, vector.y});
-    }
 
-    if (line_density_minima_local.empty()) {
+    if (solution_set.empty()) {
         std::cout << "No splay seeding lines found, which indicates a pattern being composed of +1 defects. "
                      "Proceeding with dual seeding. " << std::endl;
         return;
     }
-    std::vector<std::vector<coord>> separated_lines_of_minimal_density = separateIntoLines(line_density_minima_local,
+    std::vector<std::vector<coord>> separated_lines_of_minimal_density = separateIntoLines(solution_set,
                                                                                            {0, 0}, sqrt(2));
     if (separated_lines_of_minimal_density.size() > 1) {
         std::cout << " \t" << separated_lines_of_minimal_density.size() << " splay seeding lines found."

--- a/source/pattern/desired_pattern.cpp
+++ b/source/pattern/desired_pattern.cpp
@@ -189,24 +189,9 @@ double DesiredPattern::getDirectorY(int x, int y) const {
 
 
 coord_d DesiredPattern::getDirector(const coord_d &positions) const {
-    int x_base = floor(positions.x + 0.5);
-    int y_base = floor(positions.y + 0.5);
+    int x_base = (short)lround(positions.x);
+    int y_base = (short)lround(positions.y);
     return {getDirectorX(x_base, y_base), getDirectorY(x_base, y_base)};
-//    double x_fraction = 1 - (positions.x - floor(positions.x));
-//    double y_fraction = 1 - (positions.y - floor(positions.y));
-//
-//    double x_director =  x_fraction * y_fraction * getDirectorX(x_base, y_base);
-//    x_director += (1 - x_fraction) * y_fraction * getDirectorX(x_base + 1, y_base);
-//    x_director += (1 - x_fraction) * (1 - y_fraction) * getDirectorX(x_base + 1, y_base + 1);
-//    x_director += x_fraction * (1 - y_fraction) * getDirectorX(x_base, y_base + 1);
-//
-//    double y_director =  x_fraction * y_fraction * getDirectorY(x_base, y_base);
-//    y_director += (1 - x_fraction) * y_fraction * getDirectorY(x_base + 1, y_base);
-//    y_director += (1 - x_fraction) * (1 - y_fraction) * getDirectorY(x_base + 1, y_base + 1);
-//    y_director += x_fraction * (1 - y_fraction) * getDirectorY(x_base, y_base + 1);
-
-//    double norm = sqrt(x_director * x_director + y_director * y_director);
-//    return {x_director / norm, y_director / norm};
 }
 
 bool DesiredPattern::isInRange(const coord &coordinate) const {

--- a/source/pattern/desired_pattern.cpp
+++ b/source/pattern/desired_pattern.cpp
@@ -189,29 +189,24 @@ double DesiredPattern::getDirectorY(int x, int y) const {
 
 
 coord_d DesiredPattern::getDirector(const coord_d &positions) const {
-    int x_base = floor(positions.x);
-    int y_base = floor(positions.y);
-    double x_fraction = 1 - (positions.x - floor(positions.x));
-    double y_fraction = 1 - (positions.y - floor(positions.y));
+    int x_base = floor(positions.x + 0.5);
+    int y_base = floor(positions.y + 0.5);
+    return {getDirectorX(x_base, y_base), getDirectorY(x_base, y_base)};
+//    double x_fraction = 1 - (positions.x - floor(positions.x));
+//    double y_fraction = 1 - (positions.y - floor(positions.y));
+//
+//    double x_director =  x_fraction * y_fraction * getDirectorX(x_base, y_base);
+//    x_director += (1 - x_fraction) * y_fraction * getDirectorX(x_base + 1, y_base);
+//    x_director += (1 - x_fraction) * (1 - y_fraction) * getDirectorX(x_base + 1, y_base + 1);
+//    x_director += x_fraction * (1 - y_fraction) * getDirectorX(x_base, y_base + 1);
+//
+//    double y_director =  x_fraction * y_fraction * getDirectorY(x_base, y_base);
+//    y_director += (1 - x_fraction) * y_fraction * getDirectorY(x_base + 1, y_base);
+//    y_director += (1 - x_fraction) * (1 - y_fraction) * getDirectorY(x_base + 1, y_base + 1);
+//    y_director += x_fraction * (1 - y_fraction) * getDirectorY(x_base, y_base + 1);
 
-    double x_director =  x_fraction * y_fraction * getDirectorX(x_base, y_base);
-    x_director += (1 - x_fraction) * y_fraction * getDirectorX(x_base + 1, y_base);
-    x_director += (1 - x_fraction) * (1 - y_fraction) * getDirectorX(x_base + 1, y_base + 1);
-    x_director += x_fraction * (1 - y_fraction) * getDirectorX(x_base, y_base + 1);
-
-    double y_director =  x_fraction * y_fraction * getDirectorY(x_base, y_base);
-    y_director += (1 - x_fraction) * y_fraction * getDirectorY(x_base + 1, y_base);
-    y_director += (1 - x_fraction) * (1 - y_fraction) * getDirectorY(x_base + 1, y_base + 1);
-    y_director += x_fraction * (1 - y_fraction) * getDirectorY(x_base, y_base + 1);
-
-    return {x_director, y_director};
-//    coord_d director = {0, 0};
-//    director += x_fraction * y_fraction * getDirector(coord{x_base, y_base});
-//    director += (1 - x_fraction) * y_fraction * getDirector(coord{x_base + 1, y_base});
-//    director += (1 - x_fraction) * (1 - y_fraction) * getDirector(coord{x_base + 1, y_base + 1});
-//    director += x_fraction * (1 - y_fraction) * getDirector(coord{x_base, y_base + 1});
-
-//    return director;
+//    double norm = sqrt(x_director * x_director + y_director * y_director);
+//    return {x_director / norm, y_director / norm};
 }
 
 bool DesiredPattern::isInRange(const coord &coordinate) const {

--- a/source/pattern/desired_pattern.cpp
+++ b/source/pattern/desired_pattern.cpp
@@ -153,8 +153,10 @@ void DesiredPattern::adjustMargins() {
     adjustRowsAndColumns(shape_matrix, null_rows, null_columns);
     adjustRowsAndColumns(x_field_preferred, null_rows, null_columns);
     adjustRowsAndColumns(y_field_preferred, null_rows, null_columns);
-    adjustRowsAndColumns(splay_vector_array, null_rows, null_columns);
-    adjustRowsAndColumns(splay_array, null_rows, null_columns);
+    if (!splay_vector_array.empty()) {
+        adjustRowsAndColumns(splay_vector_array, null_rows, null_columns);
+        adjustRowsAndColumns(splay_array, null_rows, null_columns);
+    }
 
     dimensions = getTableDimensions(shape_matrix);
 }

--- a/source/pattern/filled_pattern.cpp
+++ b/source/pattern/filled_pattern.cpp
@@ -481,7 +481,7 @@ bool FilledPattern::propagatePath(Path &current_path, coord_d &positions, coord_
     fillPointsFromList(current_points_to_fill, previous_step, 1);
     // If no points were filled in this step, it indicates that the move ``bounced'' in an unpredicted direction
     // indicating the path is no longer valid as it most likely encountered a singularity.
-    if ((current_points_to_fill.empty() || norm(previous_step) < 1) && !is_discontinuity_detected) { return false; }
+    if ((current_points_to_fill.empty())) { return false; }
     if (current_path.isMovedLessThan(1, 2)) { return false; }
 
     positions = new_positions;

--- a/source/pattern/filled_pattern.cpp
+++ b/source/pattern/filled_pattern.cpp
@@ -387,18 +387,34 @@ coord_d FilledPattern::getDirector(const coord &coordinates) const {
     return desired_pattern.get().getDirector(coordinates);
 }
 
-coord_d FilledPattern::getNewStep(coord_d &real_coordinates, coord_d &previous_move, int &length) const {
-    coord_d new_move = getDirector(real_coordinates) * length;
+coord_d FilledPattern::getNewStep(coord_d &real_coordinates, coord_d &previous_move, int length) const {
+    coord_d current_director = getDirector(real_coordinates);
 
-    if (dot(new_move, previous_move) >= 0) {
-        return new_move;
-    } else {
-        return -1 * new_move;
+    if (desired_pattern.get().getDiscontinuityBehaviour() == DISCONTINUITY_STICK) {
+        coord_d previous_position = real_coordinates - previous_move;
+        coord_d previous_director = getDirector(previous_position);
+        if (abs(dot(current_director, previous_director)) < desired_pattern.get().getDiscontinuityThresholdCos()) {
+            coord_d positive_director = getDirector(real_coordinates + 2 * current_director);
+            coord_d negative_director = getDirector(real_coordinates - 2 * current_director);
+
+            if (abs(dot(current_director, positive_director)) < 0.9 * abs(dot(current_director, negative_director))) {
+                length *= -1;
+            }
+
+        } else if (dot(current_director, previous_move) < 0) {
+            length *= -1;
+        }
+    } else if (dot(current_director, previous_move) < 0) {
+        length *= -1;
     }
+
+    return length * current_director;
 }
 
 
-coord_d FilledPattern::calculateNextPosition(coord_d &positions, coord_d &previous_step, int length) {
+coord_d FilledPattern::calculateNextPosition(
+        coord_d &positions, coord_d &previous_step, int length, const Path &current_path) {
+
     coord_d new_step = getNewStep(positions, previous_step, length);
     coord_d new_positions = positions + new_step;
 
@@ -406,12 +422,11 @@ coord_d FilledPattern::calculateNextPosition(coord_d &positions, coord_d &previo
         coord_d repulsion = getLineBasedRepulsion(desired_pattern.get().getShapeMatrix(), number_of_times_filled,
                                                   new_step, new_positions, desired_pattern.get().getDimensions(),
                                                   getPrintRadius(), getRepulsion(), getRepulsionAngleCosine());
-        new_positions = new_positions + repulsion;
-        new_step = new_step + repulsion;
+        new_positions += repulsion;
     }
 
     // Check if newly generated position is valid
-    if (isTerminable(new_positions, new_step)) {
+    if (isTerminable(new_positions, current_path)) {
         return INVALID_POSITION;
     } else {
         return new_positions;
@@ -437,6 +452,34 @@ bool FilledPattern::isDirectorContinuous(const coord_d &previous_coordinates, co
     return product >= desired_pattern.get().getDiscontinuityThresholdCos();
 }
 
+coord_d FilledPattern::normalisedResultant(const coord_d &move, const coord_d &new_position,
+                                           bool is_discontinuity_detected) {
+    coord_d resultant;
+    coord_d move_direction = normalized(move);
+    coord_d new_director = getDirector(new_position);
+
+    if (is_discontinuity_detected) {
+        coord_d positive_director = getDirector(new_position + 2 * new_director);
+        coord_d negative_director = getDirector(new_position - 2 * new_director);
+
+        if (abs(dot(new_director, positive_director)) > 0.9 * abs(dot(new_director, negative_director))) {
+            resultant = move_direction + new_director;
+        } else{
+            resultant = move_direction - new_director;
+        }
+    } else {
+        if (dot(move, new_director) < 0) {
+            resultant = move_direction - new_director;
+        } else {
+            resultant = move_direction + new_director;
+        }
+    }
+
+    double projection = dot(resultant, move_direction);
+    return resultant / projection;
+}
+
+
 /// Returns bool depending whether propagation was successful.
 bool FilledPattern::propagatePath(Path &current_path, coord_d &positions, coord_d &previous_step, int length) {
     if (!desired_pattern.get().isInShape(positions)) { return false; }
@@ -444,42 +487,39 @@ bool FilledPattern::propagatePath(Path &current_path, coord_d &positions, coord_
     // Try creating the longest possible step
     coord_d new_positions = INVALID_POSITION;
     /// Keeps last valid position, even if it is discontinuous.
-    coord_d last_discontinuous_positions = INVALID_POSITION;
+    coord_d previous_discontinuous_position = INVALID_POSITION;
+    bool is_discontinuity_detected = false;
 
-    while (--length > 1 && !isValid(new_positions)) {
-        new_positions = calculateNextPosition(positions, previous_step, length);
+    while (--length > 0 && !isValid(new_positions)) {
+        new_positions = calculateNextPosition(positions, previous_step, length, current_path);
 
-        if (desired_pattern.get().isInShape(new_positions)) {
-            bool is_director_continuous = isDirectorContinuous(positions, new_positions);
-            switch (desired_pattern.get().getDiscontinuityBehaviour()) {
-                case DISCONTINUITY_IGNORE:
-                    break;
-                case DISCONTINUITY_STICK:
-                    if (is_director_continuous) {
-                        if (isValid(last_discontinuous_positions)) {
-                            new_positions = last_discontinuous_positions;
-                        }
-                        break;
-                    } else {
-                        last_discontinuous_positions = new_positions;
-                        new_positions = INVALID_POSITION;
-                    }
-                case DISCONTINUITY_TERMINATE:
-                    if (is_director_continuous) {
-                        break;
-                    } else {
-                        new_positions = INVALID_POSITION;
-                    }
-            }
+        if (!desired_pattern.get().isInShape(new_positions)) { continue; }
+
+        bool is_director_continuous = isDirectorContinuous(positions, new_positions);
+        switch (desired_pattern.get().getDiscontinuityBehaviour()) {
+            case DISCONTINUITY_IGNORE:
+                break;
+            case DISCONTINUITY_STICK:
+                if (is_director_continuous && isValid(previous_discontinuous_position)) {
+                    new_positions = previous_discontinuous_position;
+                } else if (!is_director_continuous) {
+                    previous_discontinuous_position = new_positions;
+                    is_discontinuity_detected = true;
+                    new_positions = INVALID_POSITION;
+                }
+                break;
+            case DISCONTINUITY_TERMINATE:
+                if (!is_director_continuous) { new_positions = INVALID_POSITION; }
+                break;
         }
     }
-
+    if (is_discontinuity_detected) { new_positions = previous_discontinuous_position; }
     if (!isValid(new_positions)) { return false; }
 
     previous_step = new_positions - positions;
     if (norm(previous_step) < 1) { return false; }
 
-    coord_d tangent = normalisedResultant(previous_step, getDirector(positions));
+    coord_d tangent = normalisedResultant(previous_step, new_positions, is_discontinuity_detected);
     coord_d normal = perpendicular(tangent) * getPrintRadius();
 
     current_path.addPoint(new_positions, new_positions + normal, new_positions - normal);
@@ -534,7 +574,7 @@ void FilledPattern::updatePathsOverlap() {
 }
 
 Path FilledPattern::generateNewPathForDirection(const SeedPoint &seed_point, const coord_d &starting_step) {
-    Path path(seed_point, getPrintRadius());
+    Path path(seed_point, getPrintRadius(), starting_step);
     coord_d current_positions = to_coord_d(seed_point.getCoordinates());
     coord_d current_step = starting_step;
 
@@ -548,7 +588,7 @@ Path FilledPattern::generateNewPathForDirection(const SeedPoint &seed_point, con
 
 
 Path FilledPattern::generateNewPath(const SeedPoint &seed_point) {
-    const coord_d starting_step = getDirector(seed_point.getCoordinates());
+    const coord_d starting_step = 2 * getDirector(seed_point.getCoordinates());
     Path forward_path = generateNewPathForDirection(seed_point, starting_step);
     Path backward_path = generateNewPathForDirection(seed_point, (-1) * starting_step);
 
@@ -799,15 +839,19 @@ bool FilledPattern::isTerminable(const coord &point) const {
     return false;
 }
 
-bool FilledPattern::isTerminable(const coord_d &coordinate, const coord_d &direction) {
+bool
+FilledPattern::isTerminable(const coord_d &coordinate, const Path &current_path) {
     if (!isFillable(coordinate)) { return true; }
-    if (getTerminationRadius() <= 0) { return !isFillable(coordinate); }
+    if (getTerminationRadius() <= 1) { return false; }
 
-    coord_d tangent = normalized(direction) * getTerminationRadius();
-    coord_d normal = perpendicular(tangent);
     auto point = coord(coordinate);
     for (auto &displacement: collision_list) {
-        if (isFilled(point + displacement) && isLeftOfEdge(displacement, normal, -1 * normal, true)) {
+        if (
+                isFilled(point + displacement) &&
+                isLeftOfEdge(point + displacement, current_path.getPositivePathEdge().back(),
+                             current_path.getNegativePathEdge().back(),
+                             false)
+                ) {
             return true;
         }
     }

--- a/source/pattern/filled_pattern.cpp
+++ b/source/pattern/filled_pattern.cpp
@@ -49,7 +49,7 @@ bool isValid(const coord_d &positions) {
     return positions.x >= 0 && positions.y >= 0;
 }
 
-FilledPattern::FilledPattern(const DesiredPattern &new_desired_pattern, FillingConfig new_config) :
+FilledPattern::FilledPattern(const DesiredPattern &new_desired_pattern, const FillingConfig new_config) :
         desired_pattern(std::cref(new_desired_pattern)),
         FillingConfig(new_config) {
     desired_pattern.get().isPatternUpdated();
@@ -210,7 +210,7 @@ std::vector<SeedPoint> FilledPattern::getSeedsFromRandomSeedLine() {
 //        }
 //        previous_line_end += seed_lines[j].size();
 //    }
-    
+
     std::uniform_int_distribution<> distribution(0, seed_lines.size() - 1);
     unsigned int i = distribution(random_engine);
     std::vector<coord> current_seed_line = seed_lines[i];
@@ -319,8 +319,7 @@ coord FilledPattern::findRemainingRootPoint() {
 }
 
 void FilledPattern::fillPoint(const coord &point, const coord_d &normalized_direction, int value) {
-
-    if (isInRange(point)) {
+    if (isInRange(point) && number_of_times_filled[point.x][point.y] + value >= 0) {
         number_of_times_filled[point.x][point.y] += value;
 
         if (normalized_direction.x * x_field_filled[point.x][point.y] +
@@ -333,7 +332,7 @@ void FilledPattern::fillPoint(const coord &point, const coord_d &normalized_dire
 }
 
 void FilledPattern::fillPointNonAligned(const coord &point, const coord_d &normalized_direction, int value) {
-    if (isInRange(point)) {
+    if (isInRange(point) && number_of_times_filled[point.x][point.y] + value >= 0) {
         number_of_times_filled[point.x][point.y] += value;
         x_field_filled[point.x][point.y] += normalized_direction.x * value;
         y_field_filled[point.x][point.y] += normalized_direction.y * value;

--- a/source/pattern/filled_pattern.h
+++ b/source/pattern/filled_pattern.h
@@ -76,7 +76,7 @@ class FilledPattern : public FillingConfig {
     void fillPointsFromDisplacement(const coord &starting_position, const std::vector<coord> &list_of_displacements,
                                     const coord &previous_step);
 
-    coord_d getNewStep(coord_d &real_coordinates, coord_d &previous_move, int &length) const;
+    coord_d getNewStep(coord_d &real_coordinates, coord_d &previous_move, int length) const;
 
     bool propagatePath(Path &current_path, coord_d &positions, coord_d &previous_step, int length);
 
@@ -116,7 +116,7 @@ class FilledPattern : public FillingConfig {
 
     std::vector<std::vector<SeedPoint>> separateLines(std::vector<std::vector<coord>> list_of_lines, int line_index);
 
-    coord_d calculateNextPosition(coord_d &positions, coord_d &previous_step, int length);
+    coord_d calculateNextPosition(coord_d &positions, coord_d &previous_step, int length, const Path &current_path);
 
     [[nodiscard]] bool isDirectorContinuous(const coord_d &previous_coordinates, const coord_d &new_coordinates) const;
 
@@ -132,7 +132,7 @@ class FilledPattern : public FillingConfig {
 
     bool isFillable(const coord &coordinate) const;
 
-    bool isTerminable(const coord_d &coordinate, const coord_d &direction);
+    bool isTerminable(const coord_d &coordinate, const Path &current_path);
 
     std::vector<unsigned int> findOverlappingSeedLines();
 
@@ -146,6 +146,8 @@ class FilledPattern : public FillingConfig {
 
     void extendSeedLines();
 
+    coord_d
+    normalisedResultant(const coord_d &primary_vector, const coord_d &secondary_vector, bool is_discontinuity_detected);
 
 public:
 
@@ -213,6 +215,8 @@ public:
     bool isFilled(const coord &coordinate) const;
 
     void setIsReseedingEnabled(bool is_reseeding_enabled);
+
+
 };
 
 

--- a/source/pattern/filled_pattern.h
+++ b/source/pattern/filled_pattern.h
@@ -162,7 +162,7 @@ public:
 
     FilledPattern(const DesiredPattern &desired_pattern, int print_radius, int collision_radius, int step_length);
 
-    FilledPattern(const DesiredPattern &new_desired_pattern, FillingConfig new_config);
+    FilledPattern(const DesiredPattern &new_desired_pattern, const FillingConfig new_config);
 
     /// Sets up the objects deriving from the FillingConfig
     void setup();

--- a/source/pattern/filled_pattern.h
+++ b/source/pattern/filled_pattern.h
@@ -70,18 +70,9 @@ class FilledPattern : public FillingConfig {
 
     void fillPointsFromList(const std::vector<coord> &points_to_fill, const coord_d &direction, int value);
 
-    void fillPointsFromDisplacement(const coord &starting_position, const std::vector<coord> &list_of_displacements,
-                                    const coord &previous_step, int value);
-
-    void fillPointsFromDisplacement(const coord &starting_position, const std::vector<coord> &list_of_displacements,
-                                    const coord &previous_step);
-
     coord_d getNewStep(coord_d &real_coordinates, coord_d &previous_move, int length) const;
 
     bool propagatePath(Path &current_path, coord_d &positions, coord_d &previous_step, int length);
-
-
-    [[nodiscard]] matrix_d getDualTensor(const coord &coordinates) const;
 
     double distance(const coord &first_point, const coord &second_point);
 
@@ -114,8 +105,6 @@ class FilledPattern : public FillingConfig {
 
     void setupRootPoints();
 
-    std::vector<std::vector<SeedPoint>> separateLines(std::vector<std::vector<coord>> list_of_lines, int line_index);
-
     coord_d calculateNextPosition(coord_d &positions, coord_d &previous_step, int length, const Path &current_path);
 
     [[nodiscard]] bool isDirectorContinuous(const coord_d &previous_coordinates, const coord_d &new_coordinates) const;
@@ -126,11 +115,13 @@ class FilledPattern : public FillingConfig {
 
     void updatePathOverlap(Path &path);
 
-    coord_d getDirector(const coord_d &coordinates) const;
+    [[nodiscard]] coord_d getDirector(const coord_d &coordinates) const;
 
-    coord_d getDirector(const coord &coordinates) const;
+    [[nodiscard]] coord_d getDirector(const coord &coordinates) const;
 
-    bool isFillable(const coord &coordinate) const;
+    [[nodiscard]] bool isFillable(const coord &coordinate) const;
+
+    [[nodiscard]] bool isFillable(const coord_d &coordinate) const;
 
     bool isTerminable(const coord_d &coordinate, const Path &current_path);
 
@@ -149,6 +140,10 @@ class FilledPattern : public FillingConfig {
     coord_d
     normalisedResultant(const coord_d &primary_vector, const coord_d &secondary_vector, bool is_discontinuity_detected);
 
+    [[nodiscard]] coord_d getDualDirector(const coord &coordinates) const;
+
+    [[nodiscard]] coord_d getDualDirector(const coord_d &coordinates) const;
+
 public:
 
     std::vector<std::vector<double>> x_field_filled;
@@ -164,7 +159,7 @@ public:
 
     FilledPattern(const DesiredPattern &desired_pattern, int print_radius, int collision_radius, int step_length);
 
-    FilledPattern(const DesiredPattern &new_desired_pattern, const FillingConfig new_config);
+    FilledPattern(const DesiredPattern &new_desired_pattern, FillingConfig new_config);
 
     /// Sets up the objects deriving from the FillingConfig
     void setup();
@@ -177,9 +172,6 @@ public:
 
     /// Fills points around the coordinates in a radius of print_radius
     void fillPointsInCircle(const coord &coordinates);
-
-    /// Fills points in half circle at the end of the path
-    void fillPointsInHalfCircle(const coord &last_coordinate, const coord &previous_coordinate, int value);
 
     /// Looks for a suitable point where a new path can be started from. If
     SeedPoint findSeedPoint();
@@ -200,9 +192,6 @@ public:
 
     void fillPointsInHalfCircle(const Path &path, int value, bool is_front);
 
-
-    bool isFillable(const coord_d &coordinate) const;
-
     void
     fillPointsFromDisplacementNonAligned(const coord &starting_position,
                                          const std::vector<coord> &list_of_displacements,
@@ -210,13 +199,7 @@ public:
 
     void fillPointNonAligned(const coord &point, const coord_d &normalized_direction, int value);
 
-    bool isInRange(const coord_d &index) const;
-
     bool isFilled(const coord &coordinate) const;
-
-    void setIsReseedingEnabled(bool is_reseeding_enabled);
-
-
 };
 
 

--- a/source/pattern/filling_config.cpp
+++ b/source/pattern/filling_config.cpp
@@ -32,6 +32,9 @@
 #include <unordered_map>
 #include <iomanip>
 #include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
+
+namespace fs = boost::filesystem;
 
 
 void FillingConfig::printConfig() {
@@ -214,6 +217,7 @@ void FillingConfig::readLineOfConfig(std::vector<std::string> line) {
 
 
 FillingConfig::FillingConfig(const fs::path &config_path) : FillingConfig() {
+    if (!fs::exists(config_path)) { throw std::runtime_error("ERROR: Missing config path."); }
     std::string line;
     std::ifstream file(config_path.string());
 
@@ -337,6 +341,10 @@ double FillingConfig::getRepulsionAngleCosine() const {
 
 double FillingConfig::getRepulsionAngle() const {
     return repulsion_angle;
+}
+
+bool FillingConfig::isSplayFillingEnabled() {
+    return filling_method == Splay;
 }
 
 

--- a/source/pattern/filling_config.cpp
+++ b/source/pattern/filling_config.cpp
@@ -351,3 +351,9 @@ bool FillingConfig::isSplayFillingEnabled() {
 bool isConfigOptionTheSame(configOptions option, FillingConfig &first_config, FillingConfig &second_config) {
     return first_config.getConfigOption(option) == second_config.getConfigOption(option);
 }
+
+void FillingConfig::convertToVariableWidth() {
+    repulsion = 1;
+    collision_radius = 1;
+    starting_point_separation = 2 * print_radius;
+}

--- a/source/pattern/filling_config.cpp
+++ b/source/pattern/filling_config.cpp
@@ -353,7 +353,7 @@ bool isConfigOptionTheSame(configOptions option, FillingConfig &first_config, Fi
 }
 
 void FillingConfig::convertToVariableWidth() {
-    repulsion = 1;
+    repulsion = 0;
     collision_radius = 1;
-    starting_point_separation = 2 * print_radius;
+    starting_point_separation = 2 * print_radius - 1;
 }

--- a/source/pattern/filling_config.h
+++ b/source/pattern/filling_config.h
@@ -118,6 +118,8 @@ public:
     std::string getConfigOption(configOptions option);
 
     void setSeed(int seed_value);
+
+    bool isSplayFillingEnabled(); static
 };
 
 configOptions stringToConfig(const std::string &string_option);

--- a/source/pattern/filling_config.h
+++ b/source/pattern/filling_config.h
@@ -119,7 +119,9 @@ public:
 
     void setSeed(int seed_value);
 
-    bool isSplayFillingEnabled(); static
+    bool isSplayFillingEnabled();
+
+    void convertToVariableWidth();
 };
 
 configOptions stringToConfig(const std::string &string_option);

--- a/source/pattern/importing_and_exporting/exporting.cpp
+++ b/source/pattern/importing_and_exporting/exporting.cpp
@@ -61,6 +61,7 @@ void exportHeaderToFile(const std::string &header, const fs::path &filename) {
     if (file.is_open()) {
         file << header;
     } else {
+        std::cout << "File " << filename << " failed to create." << std::endl;
         throw std::runtime_error("File " + filename.string() + " failed to create.");
     }
 }

--- a/source/pattern/importing_and_exporting/open_files.cpp
+++ b/source/pattern/importing_and_exporting/open_files.cpp
@@ -50,8 +50,8 @@ std::vector<int> readConfigTable(const fs::path &config_path) {
     return config_variables;
 }
 
-DesiredPattern openPatternFromDirectory(const fs::path &directory_path, bool is_splay_filling_enabled, int threads,
-                                        const FillingMethodConfig &filling) {
+DesiredPattern
+openPatternFromDirectory(const fs::path &directory_path, int threads, const FillingMethodConfig &filling) {
     fs::path shape_path = directory_path / "shape.csv";
     fs::path theta_field_path = directory_path / "theta_field.csv";
     fs::path x_field_path = directory_path / "xField.csv";
@@ -61,21 +61,20 @@ DesiredPattern openPatternFromDirectory(const fs::path &directory_path, bool is_
     if (!fs::exists(shape_path)) {
         throw std::runtime_error("Shape matrix does not exist in the searched directory.");
     }
-
     DesiredPattern pattern;
     if (fs::exists(theta_field_path)) {
-        pattern = {shape_path.string(), theta_field_path.string(), is_splay_filling_enabled, threads, filling};
+        pattern = {shape_path.string(), theta_field_path.string(), true, threads, filling};
     } else if (fs::exists(x_field_path) && fs::exists(y_field_path)) {
-        pattern = {shape_path.string(), x_field_path.string(), y_field_path.string(), is_splay_filling_enabled, threads, filling};
+        pattern = {shape_path.string(), x_field_path.string(), y_field_path.string(), true, threads, filling};
     } else {
         throw std::runtime_error("Neither theta nor xy field matrices are found in the searched directory.");
     }
 
     if (fs::exists(splay_path)) {
         pattern.setSplayVector(splay_path.string());
-    } else if (is_splay_filling_enabled) {
+    } else {
         std::cout
-                << "Splay filling is enabled but no splay file is provided. Calculating splay numerically - output "
+                << "No splay file is provided. Calculating splay numerically - output "
                    "quality may be decreased" << std::endl;
     }
     pattern.updateProperties();

--- a/source/pattern/importing_and_exporting/open_files.h
+++ b/source/pattern/importing_and_exporting/open_files.h
@@ -34,8 +34,8 @@
 
 namespace fs = boost::filesystem;
 
-DesiredPattern openPatternFromDirectory(const fs::path &directory_path, bool is_splay_filling_enabled, int threads,
-                                        const FillingMethodConfig &filling);
+DesiredPattern
+openPatternFromDirectory(const fs::path &directory_path, int threads, const FillingMethodConfig &filling);
 
 FilledPattern openFilledPatternFromDirectory(const fs::path &directory_path, int threads);
 

--- a/source/pattern/path.cpp
+++ b/source/pattern/path.cpp
@@ -44,9 +44,9 @@ void Path::addPoint(const coord_d &positions, const coord_d &positive_edge, cons
 }
 
 
-Path::Path(SeedPoint seed, double print_radius) : seed_point(seed) {
+Path::Path(SeedPoint seed, double print_radius, const coord_d &tangent_starting) : seed_point(seed) {
     coord_d positions = to_coord_d(seed_point.getCoordinates());
-    coord_d tangent = normalized(seed_point.getDirector());
+    coord_d tangent = normalized(tangent_starting);
     coord_d normal = perpendicular(tangent) * print_radius;
     addPoint(positions, positions + normal, positions - normal);
 }

--- a/source/pattern/path.cpp
+++ b/source/pattern/path.cpp
@@ -216,5 +216,12 @@ const std::vector<coord_d> &Path::getNegativePathEdge() const {
     return negative_path_edge;
 }
 
+bool Path::isMovedLessThan(double distance, int step_count) const {
+    /// Checks whether the path has moved than the given distance in past step counts.
+    unsigned int current_size = size();
+    if (current_size <= step_count) { return false; }
+    return norm(sequence_of_positions[current_size - step_count - 1] - last()) < distance;
+}
+
 
 

--- a/source/pattern/path.h
+++ b/source/pattern/path.h
@@ -47,7 +47,7 @@ class Path {
     double tensorDistance(const coord_d &point);
 public:
 
-    explicit Path(SeedPoint seed, double print_radius);
+    explicit Path(SeedPoint seed, double print_radius, const coord_d &tangent_starting);
 
     Path(const Path& forward_path, const Path& backward_path);
 

--- a/source/pattern/path.h
+++ b/source/pattern/path.h
@@ -96,6 +96,8 @@ public:
     std::vector<coord> findPointsToFill(int i, bool is_position_filled) const;
 
     std::vector<coord> findPointsToFill(bool is_position_filled) const;
+
+    bool isMovedLessThan(double distance, int step_count) const;
 };
 
 

--- a/source/pattern/path_sorting/nearest_neighbour.cpp
+++ b/source/pattern/path_sorting/nearest_neighbour.cpp
@@ -33,11 +33,11 @@ std::vector<Path> nearestNeighbourSort(const FilledPattern &pattern, const coord
     std::vector<Path> unsorted_paths = pattern.getSequenceOfPaths();
     std::vector<Path> sorted_paths;
     coord_d previous_end = to_coord_d(starting_coordinates);
-    int j = 0;
+
     while (!unsorted_paths.empty()) {
         int i_nearest = 0;
-        double minimal_distance = DBL_MAX;
-        for (int i = 1; i < unsorted_paths.size(); i++) {
+        auto minimal_distance = DBL_MAX;
+        for (int i = 0; i < unsorted_paths.size(); i++) {
             double current_distance = unsorted_paths[i].distance(previous_end, is_vector_sorted);
             if (current_distance < minimal_distance) {
                 i_nearest = i;

--- a/source/pattern/quantified_config.cpp
+++ b/source/pattern/quantified_config.cpp
@@ -45,7 +45,7 @@ QuantifiedConfig::QuantifiedConfig(const FilledPattern &pattern,
         Simulation(simulation) {
 }
 
-QuantifiedConfig::QuantifiedConfig(const DesiredPattern &desired_pattern, FillingConfig &filling_config,
+QuantifiedConfig::QuantifiedConfig(const DesiredPattern &desired_pattern, const FillingConfig &filling_config,
                                    const Simulation &simulation) :
         FilledPattern(desired_pattern, filling_config),
         Simulation(simulation) {

--- a/source/pattern/quantified_config.h
+++ b/source/pattern/quantified_config.h
@@ -71,7 +71,7 @@ public:
 
     QuantifiedConfig(const FilledPattern &pattern, const Simulation &simulation);
 
-    QuantifiedConfig(const DesiredPattern &desired_pattern, FillingConfig &filling_config,
+    QuantifiedConfig(const DesiredPattern &desired_pattern, const FillingConfig &filling_config,
                      const Simulation &simulation);
 
     /// Function allowing BayesianOptimisation to create new FillingConfig using vectord input

--- a/source/pattern/simulation/disagreement_function_config.cpp
+++ b/source/pattern/simulation/disagreement_function_config.cpp
@@ -153,3 +153,33 @@ double DisagreementFunctionConfig::getDirectorPower() const {
 double DisagreementFunctionConfig::getPathsPower() const {
     return paths_power;
 }
+
+void DisagreementFunctionConfig::setDirectorPower(double director_power) {
+    DisagreementFunctionConfig::director_power = director_power;
+}
+
+void DisagreementFunctionConfig::setOverlapPower(double overlap_power) {
+    DisagreementFunctionConfig::overlap_power = overlap_power;
+}
+
+void DisagreementFunctionConfig::setEmptySpotWeight(double empty_spot_weight) {
+    DisagreementFunctionConfig::empty_spot_weight = empty_spot_weight;
+}
+
+void DisagreementFunctionConfig::setEmptySpotPower(double empty_spot_power) {
+    DisagreementFunctionConfig::empty_spot_power = empty_spot_power;
+}
+
+void DisagreementFunctionConfig::setOverlapWeight(double overlap_weight) {
+    DisagreementFunctionConfig::overlap_weight = overlap_weight;
+}
+
+void DisagreementFunctionConfig::setDirectorWeight(double director_weight) {
+    DisagreementFunctionConfig::director_weight = director_weight;
+}
+
+void DisagreementFunctionConfig::setPathsPower(double paths_power) {
+    DisagreementFunctionConfig::paths_power = paths_power;
+}
+
+

--- a/source/pattern/simulation/disagreement_function_config.h
+++ b/source/pattern/simulation/disagreement_function_config.h
@@ -66,6 +66,20 @@ public:
     double getDirectorPower() const;
 
     double getPathsPower() const;
+
+    void setDirectorPower(double director_power);
+
+    void setOverlapPower(double overlap_power);
+
+    void setEmptySpotWeight(double empty_spot_weight);
+
+    void setEmptySpotPower(double empty_spot_power);
+
+    void setOverlapWeight(double overlap_weight);
+
+    void setDirectorWeight(double director_weight);
+
+    void setPathsPower(double paths_power);
 };
 
 

--- a/source/vector_slicer_api.cpp
+++ b/source/vector_slicer_api.cpp
@@ -46,3 +46,7 @@ SLICER_DLLEXPORT void slice_pattern_seeds_only(const char *pattern_directory, in
     optimisePatternSeeds(pattern_directory, pattern_path_fs / "config.txt", seeds);
 }
 
+SLICER_DLLEXPORT void slice_pattern_variable_width(const char *pattern_directory, int seeds) {
+    fs::path pattern_path_fs(pattern_directory);
+    variableWidthOptimisation(pattern_path_fs, seeds);
+}

--- a/source/vector_slicer_api.h
+++ b/source/vector_slicer_api.h
@@ -40,6 +40,9 @@ SLICER_DLLEXPORT void slice_pattern(const char *pattern_directory, bool is_defau
 /// Re-slices pattern based on previously exported best config.
 SLICER_DLLEXPORT void re_slice_pattern(const char *pattern_directory);
 
+/// Slices pattern using variable width preset, i.e. no optimisation but seeds.
+SLICER_DLLEXPORT void slice_pattern_variable_width(const char *pattern_directory, int seeds);
+
 
 
 #endif //VECTOR_SLICER_VECTOR_SLICER_API_H


### PR DESCRIPTION
Bugfix:
- Improved compatibility for newer versions of CMake, such that dependencies use CMake > 3.5.
- Fixed a bug in which the resultant paths were incorrectly sorted, due to excluding one path. 
- Improved behaviour for short paths, such that they do not get stuck.

Improvments:
- Improved behaviour in vicinity of discontinuous director.

New features:
- Added a "variable-width preset", which fills the pattern without optimisation and with the repulsion switched off. 
